### PR TITLE
Remove hash from source to fix build failure

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -1,6 +1,6 @@
 {
   "version": "1.13.0",
-  "source": "https://github.com/emcrisostomo/fswatch/releases/download/1.13.0/fswatch-1.13.0.tar.gz#c533fb6d9206814e12541282a76570412f65dc10",
+  "source": "https://github.com/emcrisostomo/fswatch/releases/download/1.13.0/fswatch-1.13.0.tar.gz",
   "override": {
     "buildsInSource": true,
     "build": [

--- a/esy.lock/.gitattributes
+++ b/esy.lock/.gitattributes
@@ -1,0 +1,3 @@
+
+# Set eol to LF so files aren't converted to CRLF-eol on Windows.
+* text eol=lf linguist-generated

--- a/esy.lock/.gitignore
+++ b/esy.lock/.gitignore
@@ -1,0 +1,3 @@
+
+# Reset any possible .gitignore, we want all esy.lock to be un-ignored.
+!*

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,0 +1,15 @@
+{
+  "checksum": "0cc961f41dbf4ff5ab5654751a4ba36e",
+  "root": "esy-fswatch@link-dev:./esy.json",
+  "node": {
+    "esy-fswatch@link-dev:./esy.json": {
+      "id": "esy-fswatch@link-dev:./esy.json",
+      "name": "esy-fswatch",
+      "version": "link-dev:./esy.json",
+      "source": { "type": "link-dev", "path": ".", "manifest": "esy.json" },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    }
+  }
+}


### PR DESCRIPTION
I'm not sure where this hash comes from and why it is desirable to have it. Perhaps it should just be replaced with a different, much better hash, but with it I get the below error and without it works.

```
error: unable to link to archive:https://github.com/emcrisostomo/fswatch/releases/download/1.13.0/fswatch-1.13.0.tar.gz#sha1:c533fb6d9206814e12541282a76570412f65dc10
  reading package metadata from link-dev:./esy.json
  loading root package metadata
esy: exiting due to errors above
```

Also not sure what might have changed since the last commit to `fswatch` was over a year ago. Not sure why this is on 0.13 either, since 0.14 is a year old too, before this was created.